### PR TITLE
Remove active bool from job

### DIFF
--- a/src/types/Job.ts
+++ b/src/types/Job.ts
@@ -4,7 +4,6 @@ export interface Job {
   payload: string
   metaData: string
   priority: number
-  active: boolean
   timeout: number
   created: Date
   failed: string | null


### PR DESCRIPTION
Since the `active` job boolean is no longer being used, this property can be removed to avoid possible queue stalls for failed jobs.